### PR TITLE
permission role seeder fix

### DIFF
--- a/database/seeds/PermissionsRoleTableSeeder.php
+++ b/database/seeds/PermissionsRoleTableSeeder.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Permission_role;
+use App\PermissionRole;
 use Illuminate\Database\Seeder;
 
 class PermissionsRoleTableSeeder extends Seeder
@@ -85,7 +85,7 @@ class PermissionsRoleTableSeeder extends Seeder
         ];
 
         foreach ($permissions_role as $permission_role) {
-            Permission_role::create($permission_role);
+            PermissionRole::create($permission_role);
         }
     }
 }


### PR DESCRIPTION
When running the `php artisan migrate --seed ` command seeding would stop and an error would appear. Couldn't find class Permission_role 