### PR TITLE
Feat: add settings page

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Helpers\Helpers;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Grid;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+class Settings extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-wrench-screwdriver';
+
+    protected static string $view = 'filament.pages.settings';
+
+    public ?array $data = [];
+
+    /** @var string|null Stores the uploaded settings file */
+    public ?string $settings_file = null;
+
+    /**
+     * Mount the page and load settings from the storage.
+     */
+    public function mount(): void
+    {
+        $settings = Helpers::getSettings();
+        $this->data = $settings;
+
+        // Ensure logo is always set correctly
+        foreach (['gym_logo'] as $logoType) {
+            if (!empty($this->data['general'][$logoType]) && is_array($this->data['general'][$logoType])) {
+                $this->data['general'][$logoType] = $this->data['general'][$logoType];
+            }
+        }
+
+        $this->form->fill($settings);
+    }
+
+    /**
+     * Define the form schema for the settings page.
+     * 
+     * @return Form
+     */
+    public function form(Form $form): Form
+    {
+        return $form
+            ->statePath('data')
+            ->schema([
+                Section::make('General')
+                    ->icon('heroicon-m-cog')
+                    ->schema([
+                        FileUpload::make('general.gym_logo')
+                            ->label('Gym Logo')
+                            ->placeholder('Upload a logo (max 10MB)')
+                            ->avatar()
+                            ->imageEditor()
+                            ->preserveFilenames()
+                            ->maxSize(1024 * 1024 * 10)
+                            ->disk('public')
+                            ->directory('images')
+                            ->image()
+                            ->extraAttributes(['class' => 'cursor-pointer'])
+                            ->afterStateUpdated(fn($state, callable $set) => $this->handleFileUpload($state, 'gym_logo', $set)),
+                        TextInput::make('general.gym_name')
+                            ->label('Gym Name'),
+                        TextInput::make('general.gym_email')
+                            ->label('Gym Email')
+                            ->email()
+                            ->prefixIcon('heroicon-o-envelope'),
+                        TextInput::make('general.gym_contact')
+                            ->numeric()
+                            ->maxLength(10)
+                            ->prefixIcon('heroicon-o-phone')
+                            ->label('Contact No.'),
+                        Grid::make(2)
+                            ->schema([
+                                Grid::make(1)
+                                    ->schema([
+                                        Textarea::make('general.address')
+                                            ->label('Address'),
+                                    ]),
+                                Grid::make(4)
+                                    ->schema([
+                                        Select::make('general.country')
+                                            ->label('Country')
+                                            ->options(Helpers::getCountries())
+                                            ->searchable()
+                                            ->reactive()
+                                            ->afterStateUpdated(fn($state, callable $set) => [
+                                                $set('general.state', null),
+                                                $set('general.city', null),
+                                            ]),
+                                        Select::make('general.state')
+                                            ->label('State')
+                                            ->options(fn($get) => Helpers::getStates($get('general.country')))
+                                            ->searchable()
+                                            ->reactive(),
+                                        Select::make('general.city')
+                                            ->label('City')
+                                            ->options(fn($get) => Helpers::getCities($get('general.state')))
+                                            ->searchable()
+                                            ->reactive(),
+                                        TextInput::make('general.zip')
+                                            ->label('Zip Code')
+                                            ->numeric()
+                                            ->maxLength(10),
+                                    ]),
+                            ])
+                    ])->columns(4),
+                Section::make('Invoice')
+                    ->icon('heroicon-m-document-text')
+                    ->schema([
+                        TextInput::make('invoice.invoice_prefix')
+                            ->label('Prefix')
+                            ->placeholder('GY'),
+                        TextInput::make('invoice.invoice_number')
+                            ->label('Number')
+                            ->numeric()
+                            ->maxLength(10),
+                        Select::make('invoice.name_type')
+                            ->label('Name Type')
+                            ->native(false)
+                            ->options([
+                                'gym_name' => 'Gym Name',
+                                'gym_logo' => 'Gym Logo'
+                            ]),
+                    ])->columns(3),
+                Section::make('Member')
+                    ->icon('heroicon-m-user-group')
+                    ->schema([
+                        TextInput::make('member.member_prefix')
+                            ->label('Prefix')
+                            ->placeholder('GY'),
+                        TextInput::make('member.member_number')
+                            ->label('Number')
+                            ->numeric()
+                            ->maxLength(10),
+                    ])->columns(2)
+            ]);
+    }
+
+    /**
+     * Saves settings to JSON file.
+     */
+    public function save()
+    {
+        $path = storage_path('data/settingsData.json');
+
+        // Ensure directory exists
+        if (!file_exists(dirname($path))) {
+            mkdir(dirname($path), 0755, true);
+        }
+        file_put_contents($path, json_encode($this->data, JSON_PRETTY_PRINT));
+
+        Notification::make()
+            ->title('Success')
+            ->body('Settings saved successfully!')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Handles the file upload process and updates the settings data.
+     *
+     * @param TemporaryUploadedFile|string|null $state The uploaded file state.
+     * @param string $key The key to store the uploaded file path in the settings.
+     * @param callable $set The callback to update the form state.
+     */
+    private function handleFileUpload($state, string $key, callable $set)
+    {
+        if (!$state instanceof TemporaryUploadedFile) {
+            return;
+        }
+
+        $path = $state->storeAs('images', $state->getClientOriginalName(), 'public');
+        $jsonPath = storage_path('data/settingsData.json');
+        $jsonData = Helpers::getSettings();
+
+        // Ensure 'business_info' and its key exist as an array
+        $jsonData['general'] = $jsonData['general'] ?? [];
+        $jsonData['general'][$key] = $path;
+
+        // Save updated data
+        if (file_put_contents($jsonPath, json_encode($jsonData, JSON_PRETTY_PRINT)) === false) {
+            throw new \RuntimeException("Failed to write to settings file.");
+        }
+
+        // Update the form state
+        $set("general.$key", [$path]);
+    }
+}

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Helpers;
+
+use Nnjeim\World\World;
+
+class Helpers
+{
+    private const SETTINGS_PATH    = 'data/settingsData.json';
+
+    /**
+     * Get the settings data from the JSON file.
+     *
+     * @return array
+     */
+    public static function getSettings(): array
+    {
+        $filePath = storage_path(self::SETTINGS_PATH);
+        return json_decode(file_get_contents($filePath), true) ?? [];
+    }
+
+    /**
+     * Get a list of all countries.
+     *
+     * @return array
+     */
+    public static function getCountries(): array
+    {
+        $response = World::countries();
+
+        if (!$response->success) {
+            return [];
+        }
+
+        return collect($response->data)
+            ->pluck('name', 'name')
+            ->toArray();
+    }
+
+    /**
+     * Get a list of states for a specific country.
+     *
+     * @param int|null $countryName The name of the country
+     * @return array
+     */
+    public static function getStates(?string $countryName): array
+    {
+        if (is_null($countryName)) {
+            return [];
+        }
+
+        // Retrieve country details to get the country code
+        $countryResponse = World::countries([
+            'filters' => ['name' => $countryName]
+        ]);
+
+        if (!$countryResponse->success || empty($countryResponse->data)) {
+            return [];
+        }
+
+        $countryId = collect($countryResponse->data)->pluck('id')->first();
+
+        if (!$countryId) {
+            return [];
+        }
+
+        // Retrieve states using the country code
+        $stateResponse = World::states([
+            'filters' => ['country_id' => $countryId]
+        ]);
+
+        if (!$stateResponse->success) {
+            return [];
+        }
+
+        return collect($stateResponse->data)
+            ->pluck('name', 'name')
+            ->toArray();
+    }
+
+    /**
+     * Get a list of cities for a specific state using its name.
+     *
+     * @param string|null $stateName The name of the state
+     * @return array
+     */
+    public static function getCities(?string $stateName): array
+    {
+        if (is_null($stateName)) {
+            return [];
+        }
+
+        // Retrieve state details to get the state code
+        $stateResponse = World::states([
+            'filters' => ['name' => $stateName]
+        ]);
+
+        if (!$stateResponse->success || empty($stateResponse->data)) {
+            return [];
+        }
+
+        $stateCode = collect($stateResponse->data)->pluck('id')->first();
+
+        if (!$stateCode) {
+            return [];
+        }
+
+        // Retrieve cities using the state code
+        $cityResponse = World::cities([
+            'filters' => ['state_id' => $stateCode]
+        ]);
+
+        if (!$cityResponse->success || empty($cityResponse->data)) {
+            return [];
+        }
+
+        return collect($cityResponse->data)
+            ->pluck('name', 'name')
+            ->toArray();
+    }
+}

--- a/resources/views/filament/pages/settings.blade.php
+++ b/resources/views/filament/pages/settings.blade.php
@@ -1,0 +1,10 @@
+<x-filament-panels::page>
+    <form wire:submit.prevent="save" class="space-y-6">
+        {{ $this->form }}
+        <div class="flex justify-end items-center space-x-4">
+            <x-filament::button type="submit" wire:loading.class="opacity-50">
+                Save Settings
+            </x-filament::button>
+        </div>
+    </form>
+</x-filament-panels::page>

--- a/storage/data/settingsData.json
+++ b/storage/data/settingsData.json
@@ -1,0 +1,22 @@
+{
+    "general": {
+        "gym_logo": [],
+        "gym_name": null,
+        "gym_email": null,
+        "gym_contact": null,
+        "address": null,
+        "country": null,
+        "state": null,
+        "city": null,
+        "zip": null
+    },
+    "invoice": {
+        "invoice_prefix": null,
+        "invoice_number": null,
+        "name_type": null
+    },
+    "member": {
+        "member_prefix": null,
+        "member_number": null
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds a Settings Page where all configuration data is stored in a single `settingsData.json` file located in the storage/data directory. To avoid repetition, helper functions have been created to handle reading from this file. 
Also, fetching location data-countries, state, and cities is also handled through these helper functions, reducing duplicate code across the application.


### Related issues
Closes #105
### Screenshot
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/f70369fe-9a5d-4c81-82e1-3deed1ff1042" />

