### PR TITLE
Feat(soft-deletion): Implement deletion prevention for related records

### DIFF
--- a/app/Filament/Resources/EnquiryResource.php
+++ b/app/Filament/Resources/EnquiryResource.php
@@ -5,7 +5,6 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\EnquiryResource\Pages;
 use App\Filament\Resources\EnquiryResource\RelationManagers\FollowUpsRelationManager;
 use App\Models\Enquiry;
-use App\Models\Service;
 use Illuminate\Database\Eloquent\Builder;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Form;
@@ -115,13 +114,14 @@ class EnquiryResource extends Resource
                             ->disabled()
                             ->color('gray'),
                         Tables\Actions\EditAction::make()->hiddenLabel(),
-                        Tables\Actions\DeleteAction::make()->hiddenLabel(),
+                        Tables\Actions\DeleteAction::make()
+                            ->hiddenLabel()
                     ])->dropdown(false)
                 ])
             ])->recordUrl(fn($record): string => route('filament.admin.resources.enquiries.view', $record->id))
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
                 ]),
             ]);
     }

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -35,6 +35,16 @@ class Subscription extends Model
     protected $dates = ['deleted_at', 'start_date', 'end_date'];
 
     /**
+     * Get the invoice for the subscription.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\hasMany
+     */
+    public function invoice()
+    {
+        return $this->hasMany(Invoice::class);
+    }
+
+    /**
      * The member who owns this subscription.
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,9 +8,13 @@ use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\DeleteAction as TableDeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -88,7 +92,70 @@ class AppServiceProvider extends ServiceProvider
          * Configure the TextColumn globally to be toggleable and hidden by default.
          */
         TextColumn::configureUsing(function (TextColumn $column) {
-            $column->toggleable(isToggledHiddenByDefault: true);
+            $column->toggleable(isToggledHiddenByDefault: false);
         });
+
+        $this->configureDeletionPrevention();
+    }
+
+    /**
+     * Prevent deletion of records that still have related data.
+     */
+    protected function configureDeletionPrevention(): void
+    {
+        $map = config('prevent-deletion', []);
+        TableDeleteAction::configureUsing(function (TableDeleteAction $action) use ($map): TableDeleteAction {
+            return $action
+                ->requiresConfirmation(function (Action $action, $record) use ($map) {
+                    $class = get_class($record);
+
+                    if (isset($map[$class])) {
+                        foreach ($map[$class] as $relation => $label) {
+                            if ($record->$relation()->exists()) {
+                                $count = $record->$relation()->count();
+                                $moduleName = class_basename($record);
+                                $action
+                                    ->modalIcon('heroicon-o-x-mark',)
+                                    ->modalHeading("Oops! Cannot Delete {$moduleName}")
+                                    ->modalDescription("This record has {$count} {$label}. Please delete them first.")
+                                    ->modalCancelAction(false)
+                                    ->modalSubmitAction(false);
+                                break;
+                            }
+                            $action->modalIcon('heroicon-o-trash');
+                        }
+                    }
+
+                    return $action;
+                });
+        }, isImportant: true);
+
+        DeleteBulkAction::configureUsing(function (DeleteBulkAction $action) use ($map): DeleteBulkAction {
+            return $action
+                ->requiresConfirmation(function (DeleteBulkAction $action, \Illuminate\Support\Collection $records) use ($map) {
+                    foreach ($records as $record) {
+                        $class = get_class($record);
+
+                        if (isset($map[$class])) {
+                            foreach ($map[$class] as $relation => $label) {
+                                if ($record->$relation()->exists()) {
+                                    $count      = $record->$relation()->count();
+                                    $moduleName = Str::pluralStudly(class_basename($record));
+                                    $action
+                                        ->modalIcon('heroicon-o-x-mark')
+                                        ->modalHeading("Oops! Cannot Delete {$moduleName}")
+                                        ->modalDescription("At least one selected {$moduleName} has {$count} {$label}. Please delete those first.")
+                                        ->modalCancelAction(false)
+                                        ->modalSubmitAction(false);
+                                    break 2;
+                                }
+                                $action->modalIcon('heroicon-o-trash');
+                            }
+                        }
+                    }
+
+                    return $action;
+                });
+        }, isImportant: true);
     }
 }

--- a/config/prevent-deletion.php
+++ b/config/prevent-deletion.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    \App\Models\Enquiry::class => [
+        'follow_up' => 'follow-ups',
+    ],
+
+    \App\Models\Service::class => [
+        'plan'  => 'plans',
+    ],
+
+    \App\Models\Member::class => [
+        'subscription'   => 'subscriptions',
+    ],
+
+    \App\Models\Plan::class => [
+        'subscription'   => 'subscriptions',
+    ],
+
+    \App\Models\Subscription::class => [
+        'invoice' => 'invoices',
+    ],
+];


### PR DESCRIPTION
### Summary
This PR enhances the SoftDeletes behavior across all models by preventing users from deleting records that have existing child relationship. On delete, we check configured relationships if any child records exist, we block the action and show a modal with the message. Otherwise, proceed with the usual soft delete.

### Related Issue
Closes #162 

### Screenshots / Screen Recording / Log

https://github.com/user-attachments/assets/d79022c8-5c43-4c0a-aed5-061ae46e438e


