### PR TITLE
Feat(invoice-module): Persist & auto-increment invoice number

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Helpers\Helpers;
+use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Grid;
@@ -113,7 +114,7 @@ class Settings extends Page implements HasForms
                                     ->native(false)
                                     ->label('Financial year end')
                                     ->suffixIcon('heroicon-o-calendar-days')
-                                    ->displayFormat('d/m/Y')
+                                    ->displayFormat('d/m/Y'),
                             ]),
                     ])
                     ->columnSpan(3),
@@ -281,6 +282,18 @@ class Settings extends Page implements HasForms
         if (!file_exists(dirname($path))) {
             mkdir(dirname($path), 0755, true);
         }
+
+        if (! empty($this->data['general']['financial_year_start'])) {
+            $this->data['general']['financial_year_start'] =
+                Carbon::parse($this->data['general']['financial_year_start'])
+                ->toDateString();
+        }
+        if (! empty($this->data['general']['financial_year_end'])) {
+            $this->data['general']['financial_year_end'] =
+                Carbon::parse($this->data['general']['financial_year_end'])
+                ->toDateString();
+        }
+
         file_put_contents($path, json_encode($this->data, JSON_PRETTY_PRINT));
 
         Notification::make()

--- a/app/Filament/Resources/EnquiryResource.php
+++ b/app/Filament/Resources/EnquiryResource.php
@@ -5,7 +5,6 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\EnquiryResource\Pages;
 use App\Filament\Resources\EnquiryResource\RelationManagers\FollowUpsRelationManager;
 use App\Models\Enquiry;
-use App\Models\Service;
 use Illuminate\Database\Eloquent\Builder;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Form;
@@ -115,13 +114,14 @@ class EnquiryResource extends Resource
                             ->disabled()
                             ->color('gray'),
                         Tables\Actions\EditAction::make()->hiddenLabel(),
-                        Tables\Actions\DeleteAction::make()->hiddenLabel(),
+                        Tables\Actions\DeleteAction::make()
+                            ->hiddenLabel()
                     ])->dropdown(false)
                 ])
             ])->recordUrl(fn($record): string => route('filament.admin.resources.enquiries.view', $record->id))
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make()
                 ]),
             ]);
     }

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -15,6 +15,17 @@ class Helpers
     private const DEFAULT_CURRENCY = 'INR';
     private const SETTINGS_PATH    = 'data/settingsData.json';
 
+    /** 
+     * If non-null, generateLastNumber() and updateLastNumber() will use
+     * this array instead of reading the disk JSON.
+     */
+    protected static ?array $testSettingsOverride = null;
+
+    public static function setTestSettingsOverride(?array $override): void
+    {
+        self::$testSettingsOverride = $override;
+    }
+
     /**
      * Get the settings data from the JSON file.
      *
@@ -22,6 +33,10 @@ class Helpers
      */
     public static function getSettings(): array
     {
+        if (static::$testSettingsOverride !== null) {
+            return static::$testSettingsOverride;
+        }
+
         $filePath = storage_path(self::SETTINGS_PATH);
 
         if (!file_exists($filePath)) {

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -35,6 +35,16 @@ class Subscription extends Model
     protected $dates = ['deleted_at', 'start_date', 'end_date'];
 
     /**
+     * Get the invoice for the subscription.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\hasMany
+     */
+    public function invoice()
+    {
+        return $this->hasMany(Invoice::class);
+    }
+
+    /**
      * The member who owns this subscription.
      * 
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,9 +8,13 @@ use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\DeleteAction as TableDeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -88,7 +92,70 @@ class AppServiceProvider extends ServiceProvider
          * Configure the TextColumn globally to be toggleable and hidden by default.
          */
         TextColumn::configureUsing(function (TextColumn $column) {
-            $column->toggleable(isToggledHiddenByDefault: true);
+            $column->toggleable(isToggledHiddenByDefault: false);
         });
+
+        $this->configureDeletionPrevention();
+    }
+
+    /**
+     * Prevent deletion of records that still have related data.
+     */
+    protected function configureDeletionPrevention(): void
+    {
+        $map = config('prevent-deletion', []);
+        TableDeleteAction::configureUsing(function (TableDeleteAction $action) use ($map): TableDeleteAction {
+            return $action
+                ->requiresConfirmation(function (Action $action, $record) use ($map) {
+                    $class = get_class($record);
+
+                    if (isset($map[$class])) {
+                        foreach ($map[$class] as $relation => $label) {
+                            if ($record->$relation()->exists()) {
+                                $count = $record->$relation()->count();
+                                $moduleName = class_basename($record);
+                                $action
+                                    ->modalIcon('heroicon-o-x-mark',)
+                                    ->modalHeading("Oops! Cannot Delete {$moduleName}")
+                                    ->modalDescription("This record has {$count} {$label}. Please delete them first.")
+                                    ->modalCancelAction(false)
+                                    ->modalSubmitAction(false);
+                                break;
+                            }
+                            $action->modalIcon('heroicon-o-trash');
+                        }
+                    }
+
+                    return $action;
+                });
+        }, isImportant: true);
+
+        DeleteBulkAction::configureUsing(function (DeleteBulkAction $action) use ($map): DeleteBulkAction {
+            return $action
+                ->requiresConfirmation(function (DeleteBulkAction $action, \Illuminate\Support\Collection $records) use ($map) {
+                    foreach ($records as $record) {
+                        $class = get_class($record);
+
+                        if (isset($map[$class])) {
+                            foreach ($map[$class] as $relation => $label) {
+                                if ($record->$relation()->exists()) {
+                                    $count      = $record->$relation()->count();
+                                    $moduleName = Str::pluralStudly(class_basename($record));
+                                    $action
+                                        ->modalIcon('heroicon-o-x-mark')
+                                        ->modalHeading("Oops! Cannot Delete {$moduleName}")
+                                        ->modalDescription("At least one selected {$moduleName} has {$count} {$label}. Please delete those first.")
+                                        ->modalCancelAction(false)
+                                        ->modalSubmitAction(false);
+                                    break 2;
+                                }
+                                $action->modalIcon('heroicon-o-trash');
+                            }
+                        }
+                    }
+
+                    return $action;
+                });
+        }, isImportant: true);
     }
 }

--- a/config/prevent-deletion.php
+++ b/config/prevent-deletion.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    \App\Models\Enquiry::class => [
+        'follow_up' => 'follow-ups',
+    ],
+
+    \App\Models\Service::class => [
+        'plan'  => 'plans',
+    ],
+
+    \App\Models\Member::class => [
+        'subscription'   => 'subscriptions',
+    ],
+
+    \App\Models\Plan::class => [
+        'subscription'   => 'subscriptions',
+    ],
+
+    \App\Models\Subscription::class => [
+        'invoice' => 'invoices',
+    ],
+];

--- a/tests/Unit/InvoiceNumberGeneratorTest.php
+++ b/tests/Unit/InvoiceNumberGeneratorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\Helpers;
+use App\Models\Invoice;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use Tests\TestCase;
+
+class InvoiceNumberGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create(2025, 6, 17));
+
+        // Prevent the Invoice::saving listener (so updateLastNumber() never writes disk)
+        Invoice::flushEventListeners();
+
+        // Override settings in-memory so we always start at "GY-1"
+        Helpers::setTestSettingsOverride([
+            'invoice' => ['prefix' => '', 'last_number' => ''],
+        ]);
+    }
+
+    #[Test]
+    #[TestDox('Step 1: Given no existing invoices → returns GY-1')]
+    public function noExistingInvoicesReturnsGY1(): void
+    {
+        $next = Helpers::generateLastNumber(
+            'invoice',
+            Invoice::class,
+            '2025-06-17'
+        );
+
+        $this->assertSame(
+            'GY-1',
+            $next,
+            'When there are no invoices at all, the next number should be GY-1'
+        );
+    }
+
+    #[Test]
+    #[TestDox('Step 2: Given two invoices in the fiscal year → returns GY-3')]
+    public function twoInRangeInvoicesReturnsGY3(): void
+    {
+        Invoice::factory()->create([
+            'number' => 'GY-1',
+            'date'   => '2025-04-01',
+        ]);
+        Invoice::factory()->create([
+            'number' => 'GY-2',
+            'date'   => '2025-05-01',
+        ]);
+
+        $next = Helpers::generateLastNumber(
+            'invoice',
+            Invoice::class,
+            '2025-06-17'
+        );
+
+        $this->assertSame(
+            'GY-3',
+            $next,
+            'With two in-year invoices (GY-1, GY-2), the next should be GY-3'
+        );
+    }
+
+    #[Test]
+    #[TestDox('Step 3: Given only out-of-range invoices → returns GY-1')]
+    public function outOfRangeInvoicesReturnsGY1(): void
+    {
+        // This one is dated before the FY start, so should be ignored
+        Invoice::factory()->create([
+            'number' => 'GY-1',
+            'date'   => '2024-03-15',
+        ]);
+
+        $next = Helpers::generateLastNumber(
+            'invoice',
+            Invoice::class,
+            '2025-06-17'
+        );
+
+        $this->assertSame(
+            'GY-1',
+            $next,
+            'An invoice before the fiscal-year cutoff should not bump the counter'
+        );
+    }
+}


### PR DESCRIPTION
### Summary
This PR enhances the invoice‐numbering system by persisting the last used number and automatically generating the next one, ensuring sequential, gap-free, and unique invoice numbers even under concurrent requests.

### Related Issue
Closes #165 

> [!NOTE]
> Test case will be refined in a future issue.
> For now, to run the test:
> ```bash
> php artisan test --filter=InvoiceNumberGeneratorTest --testdox
> ```

### Screenshots / Screen Recording / Logs

https://github.com/user-attachments/assets/67fd5498-ccd8-4162-86a9-cb6a14dbe629

