### PR TITLE
Feat(enquiry-form): Added Follow-Up, Lead Owner, and UI Tweaks

### DIFF
--- a/app/Filament/Resources/EnquiryResource.php
+++ b/app/Filament/Resources/EnquiryResource.php
@@ -15,8 +15,11 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
+use Filament\Support\Enums\FontWeight;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\HtmlString;
 
 class EnquiryResource extends Resource
 {
@@ -133,56 +136,94 @@ class EnquiryResource extends Resource
     {
         return $infolist
             ->schema([
-                Grid::make(5)
+                Section::make('Details')
+                    ->heading(function (Enquiry $record): HtmlString {
+                        $variant = match ($record->status) {
+                            'lead' => 'info',
+                            'lost' => 'danger',
+                            'member' => 'success',
+                        };
+                        $html = Blade::render(
+                            '<x-filament::badge class="inline-flex" style="margin-left:6px;" :color="$variant">
+                                        {{ ucfirst($status) }}
+                                    </x-filament::badge>',
+                            ['status' => $record->status, 'variant' => $variant]
+                        );
+                        return new HtmlString('Details ' . $html);
+                    })
                     ->schema([
-                        Section::make('Personal Information')
-                            ->schema([
-                                TextEntry::make('name'),
-                                TextEntry::make('email')->label('Email'),
-                                TextEntry::make('contact')->label('Contact'),
-                                TextEntry::make('gender')->label('Gender'),
-                                TextEntry::make('dob')
-                                    ->label('Date of Birth')
-                                    ->date('d-m-Y'),
-                                TextEntry::make('occupation')
-                                    ->label('Occupation'),
+                        TextEntry::make('name'),
+                        TextEntry::make('email')->label('Email')->copyable(),
+                        TextEntry::make('contact')->label('Contact')->copyable(),
+                        TextEntry::make('gender')->label('Gender'),
+                        TextEntry::make('dob')
+                            ->label('Date of Birth')
+                            ->date(),
+                        TextEntry::make('date')
+                            ->date(),
+                        TextEntry::make('user.name')
+                            ->label('Leade Owner')
+                            ->weight(FontWeight::Bold)
+                            ->color('success')
+                            ->url(fn($record): string => route('filament.admin.resources.users.view', $record->user_id)),
+                        TextEntry::make('start_by')
+                            ->label('Preferred Start Date')
+                            ->date()
+                            ->hidden(fn($record) => empty($record->start_by)),
+                    ])
+                    ->columns(3)
+                    ->columnSpan(4),
+                Grid::make()
+                    ->columnSpan(4)
+                    ->columns([
+                        'default' => 1,
+                        'sm'      => 2,
+                        'xl'      => 5,
+                    ])
+                    ->schema([
+                        Section::make('Location')
+                            ->columnSpan([
+                                'default' => 4,
+                                'sm'      => 1,
+                                'xl'      => 3,
                             ])
-                            ->columns(3)
-                            ->columnSpan(3),
+                            ->schema([
+                                TextEntry::make('address')->label('Address'),
+                                Group::make()
+                                    ->schema([
+                                        TextEntry::make('country')->label('Country'),
+                                        TextEntry::make('state')
+                                            ->label('State')
+                                            ->hidden(fn($record) => empty($record->state)),
+                                        TextEntry::make('city')
+                                            ->label('City')
+                                            ->hidden(fn($record) => empty($record->city)),
+                                        TextEntry::make('pincode')->label('PIN Code'),
+                                    ])
+                                    ->columns(4),
+                            ]),
                         Section::make('Preferences')
+                            ->columnSpan([
+                                'default' => 4,
+                                'sm'      => 1,
+                                'xl'      => 2,
+                            ])
+                            ->columns([
+                                'sm' => 1,
+                                'md' => 2,
+                            ])
                             ->schema([
                                 TextEntry::make('interested_in')
                                     ->label('Interested In')
+                                    ->columnSpanFull()
                                     ->hidden(fn($record) => empty($record->interested_in)),
                                 TextEntry::make('source')
                                     ->label('Source'),
-                                TextEntry::make('why_do_you_plan_to_join')
-                                    ->label('Reason for Joining'),
-                                TextEntry::make('start_by')
-                                    ->label('Preferred Start Date')
-                                    ->date('d-m-Y')
-                                    ->hidden(fn($record) => empty($record->start_by)),
-                            ])
-                            ->columns(2)
-                            ->columnSpan(2),
-                    ]),
-                Section::make('Address')
-                    ->schema([
-                        TextEntry::make('address')->label('Address'),
-                        Group::make()
-                            ->schema([
-                                TextEntry::make('country')->label('Country'),
-                                TextEntry::make('state')
-                                    ->label('State')
-                                    ->hidden(fn($record) => empty($record->state)),
-                                TextEntry::make('city')
-                                    ->label('City')
-                                    ->hidden(fn($record) => empty($record->city)),
-                                TextEntry::make('pincode')->label('PIN Code'),
-                            ])
-                            ->columns(4),
-                    ]),
-            ]);
+                                TextEntry::make('fitness_goal')
+                                    ->label('Fitness goal ?'),
+                            ]),
+                    ])
+            ])->columns(4);
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/EnquiryResource.php
+++ b/app/Filament/Resources/EnquiryResource.php
@@ -169,7 +169,7 @@ class EnquiryResource extends Resource
                         TextEntry::make('start_by')
                             ->label('Preferred Start Date')
                             ->date()
-                            ->hidden(fn($record) => empty($record->start_by)),
+                            ->placeholder('N/A'),
                     ])
                     ->columns(3)
                     ->columnSpan(4),
@@ -194,10 +194,10 @@ class EnquiryResource extends Resource
                                         TextEntry::make('country')->label('Country'),
                                         TextEntry::make('state')
                                             ->label('State')
-                                            ->hidden(fn($record) => empty($record->state)),
+                                            ->placeholder('N/A'),
                                         TextEntry::make('city')
                                             ->label('City')
-                                            ->hidden(fn($record) => empty($record->city)),
+                                            ->placeholder('N/A'),
                                         TextEntry::make('pincode')->label('PIN Code'),
                                     ])
                                     ->columns(4),
@@ -216,7 +216,7 @@ class EnquiryResource extends Resource
                                 TextEntry::make('interested_in')
                                     ->label('Interested In')
                                     ->columnSpanFull()
-                                    ->hidden(fn($record) => empty($record->interested_in)),
+                                    ->placeholder('N/A'),
                                 TextEntry::make('source')
                                     ->label('Source'),
                                 TextEntry::make('fitness_goal')

--- a/app/Filament/Resources/EnquiryResource.php
+++ b/app/Filament/Resources/EnquiryResource.php
@@ -219,8 +219,8 @@ class EnquiryResource extends Resource
                                     ->placeholder('N/A'),
                                 TextEntry::make('source')
                                     ->label('Source'),
-                                TextEntry::make('fitness_goal')
-                                    ->label('Fitness goal ?'),
+                                TextEntry::make('goal')
+                                    ->label('Goal ?'),
                             ]),
                     ])
             ])->columns(4);

--- a/app/Filament/Resources/EnquiryResource/Pages/CreateEnquiry.php
+++ b/app/Filament/Resources/EnquiryResource/Pages/CreateEnquiry.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\EnquiryResource\Pages;
 
 use App\Filament\Resources\EnquiryResource;
-use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateEnquiry extends CreateRecord
 {
     protected static string $resource = EnquiryResource::class;
+
+    public function getTitle(): string
+    {
+        return 'New enquiry';
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Sales',
+            EnquiryResource::getUrl('index')   => 'Enquiries',
+        ];
+    }
 }

--- a/app/Filament/Resources/EnquiryResource/Pages/EditEnquiry.php
+++ b/app/Filament/Resources/EnquiryResource/Pages/EditEnquiry.php
@@ -18,9 +18,19 @@ class EditEnquiry extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Actions\ViewAction::make(),
             Actions\DeleteAction::make(),
             Actions\ForceDeleteAction::make(),
             Actions\RestoreAction::make(),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Sales',
+            EnquiryResource::getUrl('index')   => 'Enquiries',
+            $this->record->name,
         ];
     }
 }

--- a/app/Filament/Resources/EnquiryResource/Pages/ListEnquiries.php
+++ b/app/Filament/Resources/EnquiryResource/Pages/ListEnquiries.php
@@ -16,7 +16,15 @@ class ListEnquiries extends ListRecords
         return [
             Actions\CreateAction::make()
                 ->icon('heroicon-m-plus')
-                ->hidden(!Enquiry::exists()),        
-            ];
+                ->hidden(!Enquiry::exists()),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Sales',
+            'Enquiries',
+        ];
     }
 }

--- a/app/Filament/Resources/EnquiryResource/Pages/ViewEnquiry.php
+++ b/app/Filament/Resources/EnquiryResource/Pages/ViewEnquiry.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\EnquiryResource\Pages;
 
 use App\Filament\Resources\EnquiryResource;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
 
@@ -12,13 +13,23 @@ class ViewEnquiry extends ViewRecord
 
     public function getTitle(): string
     {
-        return 'View ' . $this->record->name;
+        return 'Enquiry ' . $this->record->name;
     }
 
     protected function getHeaderActions(): array
     {
         return [
             EditAction::make(),
+            DeleteAction::make()
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Sales',
+            EnquiryResource::getUrl('index')   => 'Enquiries',
+            $this->record->name,
         ];
     }
 }

--- a/app/Models/Enquiry.php
+++ b/app/Models/Enquiry.php
@@ -238,8 +238,8 @@ class Enquiry extends Model
                         ->columns(2)
                         ->maxItems(1)
                         ->deletable(false)
-                        ->hiddenOn('edit')
-                ]),
+                ])
+                ->hiddenOn('edit'),
         ];
     }
 

--- a/app/Models/Enquiry.php
+++ b/app/Models/Enquiry.php
@@ -49,7 +49,7 @@ class Enquiry extends Model
         'pincode',
         'interested_in',
         'source',
-        'fitness_goal',
+        'goal',
         'start_by'
     ];
 
@@ -200,7 +200,7 @@ class Enquiry extends Model
                             'others' => 'Others'
                         ])->default('promotions')
                         ->selectablePlaceholder(false),
-                    Select::make('fitness_goal')
+                    Select::make('goal')
                         ->options([
                             'fitness' => 'Fitness',
                             'body_building' => 'Body Building',
@@ -208,7 +208,7 @@ class Enquiry extends Model
                             'weightgain' => 'Weightgain',
                             'others' => 'Others'
                         ])->default('fitness')
-                        ->label('Fitness goal ?')
+                        ->label('Goal ?')
                         ->selectablePlaceholder(false),
                 ])->columns(3),
             Section::make('Follow Details')

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,8 @@ use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Select;
+use Filament\Support\Assets\Css;
+use Filament\Support\Facades\FilamentAsset;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\DeleteAction as TableDeleteAction;
 use Filament\Tables\Actions\DeleteBulkAction;
@@ -32,6 +34,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        FilamentAsset::register([
+            Css::make('gymie-styles', __DIR__ . '/../../resources/css/custom.css'),
+        ]);
+
         /**
          * Configure the CreateAction globally to use a specific icon.
          */

--- a/database/factories/EnquiryFactory.php
+++ b/database/factories/EnquiryFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Service;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -18,13 +19,13 @@ class EnquiryFactory extends Factory
     public function definition(): array
     {
         return [
+            'user_id' => User::factory(),
             'name' => $this->faker->name,
             'email' => $this->faker->unique()->safeEmail,
             'contact' => $this->faker->numerify('+##-##########'),
-            'date' =>$this->faker->date(now()),
+            'date' => $this->faker->date(now()),
             'gender' => $this->faker->randomElement(['male', 'female', 'other']),
             'dob' => $this->faker->date('d-m-Y', '-15 years'),
-            'occupation' => $this->faker->randomElement(['student', 'housewife', 'self_employed', 'professional', 'freelancer', 'others']),
             'status' => $this->faker->randomElement(['lead', 'member', 'lost']),
             'address' => $this->faker->address,
             'country' => $this->faker->country,
@@ -33,7 +34,7 @@ class EnquiryFactory extends Factory
             'pincode' => $this->faker->randomNumber(6, 0),
             'interested_in' => Service::inRandomOrder()->limit(rand(1, 5))->pluck('name')->toArray(),
             'source' => $this->faker->randomElement(['promotions', 'word_of_mouth', 'others']),
-            'why_do_you_plan_to_join' => $this->faker->randomElement(['fitness', 'body_building', 'fatloss', 'weightgain', 'others']),
+            'fitness_goal' => $this->faker->randomElement(['fitness', 'body_building', 'fatloss', 'weightgain', 'others']),
             'start_by' => $this->faker->dateTimeBetween('now', '+1 month')->format('d-m-Y'),
         ];
     }

--- a/database/factories/EnquiryFactory.php
+++ b/database/factories/EnquiryFactory.php
@@ -34,7 +34,7 @@ class EnquiryFactory extends Factory
             'pincode' => $this->faker->randomNumber(6, 0),
             'interested_in' => Service::inRandomOrder()->limit(rand(1, 5))->pluck('name')->toArray(),
             'source' => $this->faker->randomElement(['promotions', 'word_of_mouth', 'others']),
-            'fitness_goal' => $this->faker->randomElement(['fitness', 'body_building', 'fatloss', 'weightgain', 'others']),
+            'goal' => $this->faker->randomElement(['fitness', 'body_building', 'fatloss', 'weightgain', 'others']),
             'start_by' => $this->faker->dateTimeBetween('now', '+1 month')->format('d-m-Y'),
         ];
     }

--- a/database/migrations/2025_05_26_020228_create_enquiries_table.php
+++ b/database/migrations/2025_05_26_020228_create_enquiries_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
             $table->enum('status', ['lead', 'member', 'lost'])->default('lead')->nullable();
             $table->json('interested_in')->nullable();
             $table->string('source')->nullable();
-            $table->string('fitness_goal')->nullable();
+            $table->string('goal')->nullable();
             $table->date('start_by')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/database/migrations/2025_05_26_020228_create_enquiries_table.php
+++ b/database/migrations/2025_05_26_020228_create_enquiries_table.php
@@ -13,22 +13,22 @@ return new class extends Migration
     {
         Schema::create('enquiries', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->string('name')->nullable();
             $table->string('email')->unique()->nullable();
             $table->string('contact')->nullable();
             $table->date('date')->nullable()->default(now());
-            $table->enum('gender', ['male' , 'female', 'other'])->default('male')->nullable();
+            $table->enum('gender', ['male', 'female', 'other'])->default('male')->nullable();
             $table->date('dob')->nullable();
-            $table->enum('occupation', ['student','housewife', 'self_employed', 'professional', 'freelancer', 'others'])->default('student')->nullable();
-            $table->enum('status', ['lead', 'member', 'lost'])->default('lead')->nullable();
             $table->text('address')->nullable();
             $table->string('country')->nullable();
             $table->string('city')->nullable();
             $table->string('state')->nullable();
             $table->text('pincode')->nullable();
+            $table->enum('status', ['lead', 'member', 'lost'])->default('lead')->nullable();
             $table->json('interested_in')->nullable();
-            $table->enum('source', ['promotions', 'word_of_mouth', 'others'])->default('promotions')->nullable();
-            $table->enum('why_do_you_plan_to_join', ['fitness', 'body_building', 'fatloss', 'weightgain', 'others'])->default('fitness')->nullable();
+            $table->string('source')->nullable();
+            $table->string('fitness_goal')->nullable();
             $table->date('start_by')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/public/css/app/gymie-styles.css
+++ b/public/css/app/gymie-styles.css
@@ -1,0 +1,6 @@
+.new_enquiry_follow_up li {
+    box-shadow: none;
+}
+.new_enquiry_follow_up .fi-fo-repeater-item-content {
+    padding: 0px;
+}

--- a/resources/css/custom.css
+++ b/resources/css/custom.css
@@ -1,0 +1,6 @@
+.new_enquiry_follow_up li {
+    box-shadow: none;
+}
+.new_enquiry_follow_up .fi-fo-repeater-item-content {
+    padding: 0px;
+}


### PR DESCRIPTION
### Summary
This PR adds a Follow-Up section directly to the enquiry creation form, so users can log follow-ups right away without revisiting. Also added a Lead Owner field to assign responsibility early on.

### Related Issue
Closes #172 

### Changes

1. Added `Follow-Up` section to the enquiry form
2. Introduced `Lead Owner` field for assigning responsibility during creation
3. Improved breadcrumbs for better navigation
4. Replaced `why_do_you_plan_to_join` with `fitness_goal`
5. Removed the `Occupation` field
6. Refined the enquiry view page layout

### Screenshots / Screen Recording / Logs

https://github.com/user-attachments/assets/c5b20837-e724-49ac-bed4-383b56db63cd