### PR TITLE
Feat(member-module): Persist & auto-increment member code 

### DIFF
--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Get;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -90,6 +91,13 @@ class Member extends Model
     {
         parent::boot();
 
+        static::saving(function ($member) {
+            if (!$member->code) {
+                $member->code = Helpers::generateLastNumber('member', Member::class, null, 'code');
+            }
+            Helpers::updateLastNumber('member', $member->code);
+        });
+
         static::deleting(function ($resource) {
             foreach (static::$relations_to_cascade as $relation) {
                 foreach ($resource->{$relation}()->get() as $item) {
@@ -143,7 +151,13 @@ class Member extends Model
                                             TextInput::make('code')
                                                 ->placeholder('Code for the member')
                                                 ->label('Member Code')
-                                                ->required(),
+                                                ->required()
+                                                ->default(fn(Get $get) => Helpers::generateLastNumber(
+                                                    'member',
+                                                    Member::class,
+                                                    null,
+                                                    'code'
+                                                )),
                                             TextInput::make('name')
                                                 ->required()
                                                 ->maxLength(255)

--- a/tests/Unit/InvoiceNumberGeneratorTest.php
+++ b/tests/Unit/InvoiceNumberGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use App\Helpers\Helpers;
 use App\Models\Invoice;
+use App\Models\Member;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
@@ -20,8 +21,9 @@ class InvoiceNumberGeneratorTest extends TestCase
 
         Carbon::setTestNow(Carbon::create(2025, 6, 17));
 
-        // Prevent the Invoice::saving listener (so updateLastNumber() never writes disk)
+        // Prevent the listener (so updateLastNumber() never writes disk)
         Invoice::flushEventListeners();
+        Member::flushEventListeners();
 
         // Override settings in-memory so we always start at "GY-1"
         Helpers::setTestSettingsOverride([

--- a/tests/Unit/MemberCodeGeneratorTest.php
+++ b/tests/Unit/MemberCodeGeneratorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helpers\Helpers;
+use App\Models\Member;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use Tests\TestCase;
+
+class MemberCodeGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create(2025, 6, 17));
+
+        // Prevent the Member::saving listener (so updateLastNumber() never writes disk)
+        Member::flushEventListeners();
+
+        // Override settings in-memory so we always start at "GY-1"
+        Helpers::setTestSettingsOverride([
+            'member' => ['prefix' => '', 'last_number' => ''],
+        ]);
+    }
+
+    #[Test]
+    #[TestDox('Step 1: Given no existing members → returns GY-1')]
+    public function noExistingMembersReturnsGY1(): void
+    {
+        $next = Helpers::generateLastNumber(
+            'member',
+            Member::class,
+            null,
+            'code'
+        );
+
+        $this->assertSame(
+            'GY-1',
+            $next,
+            'When there are no members at all, the next number should be GY-1'
+        );
+    }
+
+    #[Test]
+    #[TestDox('Step 2: Given two members in the fiscal year → returns GY-3')]
+    public function twoInRangeMembersReturnsGY3(): void
+    {
+        Member::factory()->create([
+            'code' => 'GY-1'
+        ]);
+        Member::factory()->create([
+            'code' => 'GY-2'
+        ]);
+
+        $next = Helpers::generateLastNumber(
+            'member',
+            Member::class,
+            null,
+            'code'
+        );
+
+        $this->assertSame(
+            'GY-3',
+            $next,
+            'With two in-year members (GY-1, GY-2), the next should be GY-3'
+        );
+    }
+
+    #[Test]
+    #[TestDox('Step 3: Given only out-of-range members → returns GY-1')]
+    public function outOfRangeMembersReturnsGY1(): void
+    {
+        // This one is dated before the FY start, so should be ignored
+        Member::factory()->create([
+            'code' => 'GY-1',
+            'created_at' => Carbon::create(2025, 3, 31, 23, 59, 59),
+        ]);
+
+        $next = Helpers::generateLastNumber(
+            'member',
+            Member::class,
+            null,
+            'code'
+        );
+
+        $this->assertSame(
+            'GY-1',
+            $next,
+            'An member before the fiscal-year cutoff should not bump the counter'
+        );
+    }
+}


### PR DESCRIPTION
### Summary
This PR enhances the member‐code system by persisting the last used number and automatically generating the next one, ensuring sequential, gap-free, and unique member code even under concurrent requests.

### Related Issue
Closes #168

> [!NOTE]
> Test case will be refined in a future issue.
> For now, to run the test:
> ```bash
> php artisan test --filter=MemberCodeGeneratorTest --testdox
> ```

### Screenshots / Screen Recording / Logs

https://github.com/user-attachments/assets/6bfdd213-18f5-4287-bcaa-2fd98fa7dfb5

