### PR TITLE
Refactor(relationship-name): Standardize Eloquent relationship methods to camelCase

### DIFF
--- a/app/Models/Enquiry.php
+++ b/app/Models/Enquiry.php
@@ -26,7 +26,7 @@ class Enquiry extends Model
      *
      * @var string[]
      */
-    protected static $relations_to_cascade = ['follow_up'];
+    protected static $relations_to_cascade = ['followUps'];
 
     /**
      * The attributes that are mass assignable.
@@ -63,11 +63,11 @@ class Enquiry extends Model
     protected $dates = ['deleted_at'];
 
     /**
-     * Get the follow-up for the enquiry.
+     * Get the followUps for the enquiry.
      *
      * @return \Illuminate\Database\Eloquent\Relations\hasMany
      */
-    public function follow_up()
+    public function followUps()
     {
         return $this->hasMany(FollowUp::class);
     }
@@ -213,8 +213,8 @@ class Enquiry extends Model
                 ])->columns(3),
             Section::make('Follow Details')
                 ->schema([
-                    Repeater::make('follow_up')
-                        ->relationship('follow_up')
+                    Repeater::make('followUps')
+                        ->relationship('followUps')
                         ->itemLabel('')
                         ->hiddenLabel()
                         ->columnSpanFull()

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -28,7 +28,7 @@ class Member extends Model
      *
      * @var string[]
      */
-    protected static $relations_to_cascade = ['subscription'];
+    protected static $relations_to_cascade = ['subscriptions'];
 
     /**
      * The attributes that are mass assignable.
@@ -75,11 +75,11 @@ class Member extends Model
     ];
 
     /**
-     * Get the subscription for the member.
+     * Get the subscriptions for the member.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function subscription()
+    public function subscriptions()
     {
         return $this->hasMany(Subscription::class);
     }

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -22,7 +22,7 @@ class Plan extends Model
      *
      * @var string[]
      */
-    protected static $relations_to_cascade = ['subscription'];
+    protected static $relations_to_cascade = ['subscriptions'];
 
     /**
      * The attributes that are mass assignable.
@@ -52,11 +52,11 @@ class Plan extends Model
     }
 
     /**
-     * Get the subscription for the plan.
+     * Get the subscriptions for the plan.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function subscription()
+    public function subscriptions()
     {
         return $this->hasMany(Subscription::class);
     }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -18,7 +18,7 @@ class Service extends Model
      *
      * @var string[]
      */
-    protected static $relations_to_cascade = ['plan'];
+    protected static $relations_to_cascade = ['plans'];
 
     /**
      * The attributes that are mass assignable.
@@ -33,11 +33,11 @@ class Service extends Model
     protected $dates = ['deleted_at'];
 
     /**
-     * Get the plan for the service.
+     * Get the plans for the service.
      *
      * @return \Illuminate\Database\Eloquent\Relations\hasMany
      */
-    public function plan()
+    public function plans()
     {
         return $this->hasMany(Plan::class);
     }

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -35,11 +35,11 @@ class Subscription extends Model
     protected $dates = ['deleted_at', 'start_date', 'end_date'];
 
     /**
-     * Get the invoice for the subscription.
+     * Get the invoices for the subscription.
      * 
      * @return \Illuminate\Database\Eloquent\Relations\hasMany
      */
-    public function invoice()
+    public function invoices()
     {
         return $this->hasMany(Invoice::class);
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -116,10 +116,11 @@ class AppServiceProvider extends ServiceProvider
                     $class = get_class($record);
 
                     if (isset($map[$class])) {
-                        foreach ($map[$class] as $relation => $label) {
+                        foreach ($map[$class] as $relation) {
                             if ($record->$relation()->exists()) {
                                 $count = $record->$relation()->count();
                                 $moduleName = class_basename($record);
+                                $label = Str::kebab($relation);
                                 $action
                                     ->modalIcon('heroicon-o-x-mark',)
                                     ->modalHeading("Oops! Cannot Delete {$moduleName}")
@@ -143,10 +144,11 @@ class AppServiceProvider extends ServiceProvider
                         $class = get_class($record);
 
                         if (isset($map[$class])) {
-                            foreach ($map[$class] as $relation => $label) {
+                            foreach ($map[$class] as $relation) {
                                 if ($record->$relation()->exists()) {
                                     $count      = $record->$relation()->count();
                                     $moduleName = Str::pluralStudly(class_basename($record));
+                                    $label = Str::kebab($relation);
                                     $action
                                         ->modalIcon('heroicon-o-x-mark')
                                         ->modalHeading("Oops! Cannot Delete {$moduleName}")

--- a/config/prevent-deletion.php
+++ b/config/prevent-deletion.php
@@ -1,23 +1,13 @@
 <?php
 
 return [
-    \App\Models\Enquiry::class => [
-        'follow_up' => 'follow-ups',
-    ],
+    \App\Models\Enquiry::class => ['followUps'],
 
-    \App\Models\Service::class => [
-        'plan'  => 'plans',
-    ],
+    \App\Models\Service::class => ['plans'],
 
-    \App\Models\Member::class => [
-        'subscription'   => 'subscriptions',
-    ],
+    \App\Models\Member::class => ['subscriptions'],
 
-    \App\Models\Plan::class => [
-        'subscription'   => 'subscriptions',
-    ],
+    \App\Models\Plan::class => ['subscriptions'],
 
-    \App\Models\Subscription::class => [
-        'invoice' => 'invoices',
-    ],
+    \App\Models\Subscription::class => ['invoices'],
 ];


### PR DESCRIPTION
### Summary
Renamed all relationship methods from `snake_case` to `camelCase`

### Related Issue
Closes #174 

> [!NOTE]
> I will open a follow-up issue to add test coverage for this so future PRs are checked via test command