### PR TITLE
Feat(enquiries-table): Add filter by statuses tabs

### DIFF
--- a/app/Enums/Status.php
+++ b/app/Enums/Status.php
@@ -20,6 +20,9 @@ enum Status: string implements HasColor, HasLabel
     case Ongoing   = 'ongoing';
     case Expiring  = 'expiring';
     case Expired   = 'expired';
+    case Lead      = 'lead';
+    case Lost      = 'lost';
+    case Member    = 'member';
 
     private const COLORS = [
         self::Pending->value    => 'warning',
@@ -35,6 +38,9 @@ enum Status: string implements HasColor, HasLabel
         self::Ongoing->value    => 'info',
         self::Expiring->value   => 'warning',
         self::Expired->value    => 'danger',
+        self::Lead->value       => 'info',
+        self::Lost->value       => 'danger',
+        self::Member->value     => 'success',
     ];
 
     public function getLabel(): string

--- a/app/Filament/Resources/EnquiryResource/Pages/ListEnquiries.php
+++ b/app/Filament/Resources/EnquiryResource/Pages/ListEnquiries.php
@@ -2,10 +2,13 @@
 
 namespace App\Filament\Resources\EnquiryResource\Pages;
 
+use App\Enums\Status;
 use App\Filament\Resources\EnquiryResource;
 use App\Models\Enquiry;
 use Filament\Actions;
+use Filament\Resources\Components\Tab;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Builder;
 
 class ListEnquiries extends ListRecords
 {
@@ -25,6 +28,25 @@ class ListEnquiries extends ListRecords
         return [
             'Sales',
             'Enquiries',
+        ];
+    }
+
+    public function getTabs(): array
+    {
+        return [
+            'all' => Tab::make('All'),
+            'lead' => Tab::make('Lead')
+                ->badge(Enquiry::query()->where('status', 'lead')->count())
+                ->badgeColor(Status::Lead->getColor())
+                ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'lead')),
+            'member' => Tab::make('Member')
+                ->badge(Enquiry::query()->where('status', 'member')->count())
+                ->badgeColor(Status::Member->getColor())
+                ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'member')),
+            'lost' => Tab::make('Lost')
+                ->badge(Enquiry::query()->where('status', 'lost')->count())
+                ->badgeColor(Status::Lost->getColor())
+                ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'lost')),
         ];
     }
 }

--- a/app/Models/Enquiry.php
+++ b/app/Models/Enquiry.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\Status;
 use App\Helpers\Helpers;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Group;
@@ -58,6 +59,7 @@ class Enquiry extends Model
         'date'          => 'date',
         'dob'           => 'date',
         'start_by'      => 'date',
+        'status'        => Status::class
     ];
 
     protected $dates = ['deleted_at'];
@@ -258,19 +260,9 @@ class Enquiry extends Model
             TextColumn::make('date')->sortable()->date('d-m-Y')->toggleable(isToggledHiddenByDefault: true)->label('Date'),
             TextColumn::make('start_by')->date('d-m-Y')->toggleable(isToggledHiddenByDefault: true)->label('Start by'),
             TextColumn::make('status')
-                ->color(fn(string $state): string => match ($state) {
-                    'lead' => 'info',
-                    'member' => 'success',
-                    'lost' => 'danger',
-                })->badge()
+                ->badge()
                 ->label('Status')
-                ->toggleable(isToggledHiddenByDefault: false)
-                ->formatStateUsing(fn(string $state): string => match ($state) {
-                    'lead' => 'Lead',
-                    'member' => 'Member',
-                    'lost' => 'Lost',
-                    default => ucfirst($state), // Fallback for any unexpected status
-                }),
+                ->toggleable(isToggledHiddenByDefault: false),
         ];
     }
 }


### PR DESCRIPTION
### Summary
This PR adds a set of horizontal status filter tabs above the enquiries table to enable filtering enquiries by their status. The available tabs include All, Lead, Lost, and Member, matching the existing status values used in the system. Each tab displays a dynamic count badge showing the number of enquiries in that category (e.g., "Lead (42)"). Selecting a tab filters the enquiries list accordingly, while clicking on the All tab resets the filter to show all enquiries.

### Related Issue
Closes #185

### Screenshots / Screen Recording / Logs

https://github.com/user-attachments/assets/d1853d15-d3b2-46b3-b589-21ae74e2ac93

