### PR TITLE
Feature(member-form): Add Subscription & Invoice Fields to Member Creation Form 

### DIFF
--- a/app/Filament/Resources/InvoiceResource/Pages/CreateInvoice.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/CreateInvoice.php
@@ -3,10 +3,22 @@
 namespace App\Filament\Resources\InvoiceResource\Pages;
 
 use App\Filament\Resources\InvoiceResource;
-use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateInvoice extends CreateRecord
 {
     protected static string $resource = InvoiceResource::class;
+
+    public function getTitle(): string
+    {
+        return 'New Invoice';
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Billing',
+            InvoiceResource::getUrl('index')   => 'Invoices',
+        ];
+    }
 }

--- a/app/Filament/Resources/InvoiceResource/Pages/EditInvoice.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/EditInvoice.php
@@ -24,4 +24,13 @@ class EditInvoice extends EditRecord
             Actions\RestoreAction::make(),
         ];
     }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Billing',
+            InvoiceResource::getUrl('index')   => 'Invoices',
+            $this->record->number
+        ];
+    }
 }

--- a/app/Filament/Resources/InvoiceResource/Pages/ListInvoices.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/ListInvoices.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\InvoiceResource\Pages;
 
+use App\Enums\Status;
 use App\Filament\Resources\InvoiceResource;
 use App\Models\Invoice;
 use Filament\Actions;
@@ -17,7 +18,7 @@ class ListInvoices extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-            ->visible(Invoice::exists()),
+                ->visible(Invoice::exists()),
         ];
     }
 
@@ -27,29 +28,37 @@ class ListInvoices extends ListRecords
             'all' => Tab::make('All'),
             'issued' => Tab::make('Issued')
                 ->badge(Invoice::query()->where('status', 'issued')->count())
-                ->badgeColor('gray')
+                ->badgeColor(Status::Issued->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'issued')),
             'partial' => Tab::make('Partially Paid')
                 ->badge(Invoice::query()->where('status', 'partial')->count())
-                ->badgeColor('info')
+                ->badgeColor(Status::Partial->getColor())
                 ->label('Partial')
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'partial')),
             'overdue' => Tab::make('Overdue')
                 ->badge(Invoice::query()->where('status', 'overdue')->count())
-                ->badgeColor('warning')
+                ->badgeColor(Status::Overdue->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'overdue')),
             'paid' => Tab::make('Paid')
                 ->badge(Invoice::query()->where('status', 'paid')->count())
-                ->badgeColor('success')
+                ->badgeColor(Status::Paid->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'paid')),
             'refund' => Tab::make('Refund')
                 ->badge(Invoice::query()->where('status', 'refund')->count())
-                ->badgeColor('danger')
+                ->badgeColor(Status::Refund->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'refund')),
             'cancelled' => Tab::make('Cancelled')
                 ->badge(Invoice::query()->where('status', 'cancelled')->count())
-                ->badgeColor('danger')
+                ->badgeColor(Status::Cancelled->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'cancelled')),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Billing',
+            InvoiceResource::getUrl('index')   => 'Invoices',
         ];
     }
 }

--- a/app/Filament/Resources/InvoiceResource/Pages/ViewInvoice.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/ViewInvoice.php
@@ -13,7 +13,7 @@ class ViewInvoice extends ViewRecord
 
     public function getTitle(): string
     {
-        return 'View Invoice No. #' . $this->record->number;
+        return 'Invoice No. #' . $this->record->number;
     }
 
     protected function getHeaderActions(): array
@@ -21,6 +21,15 @@ class ViewInvoice extends ViewRecord
         return [
             EditAction::make(),
             DeleteAction::make()
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Billing',
+            InvoiceResource::getUrl('index')   => 'Invoices',
+            $this->record->number
         ];
     }
 }

--- a/app/Filament/Resources/MemberResource/Pages/CreateMember.php
+++ b/app/Filament/Resources/MemberResource/Pages/CreateMember.php
@@ -12,6 +12,8 @@ class CreateMember extends CreateRecord
 {
     protected static string $resource = MemberResource::class;
 
+    protected static bool $canCreateAnother = false;
+
     public ?int $enquiryId = null;
 
     public function mount(): void
@@ -57,5 +59,18 @@ class CreateMember extends CreateRecord
             ->body('Enquiry has been successfully converted to a member.')
             ->success()
             ->send();
+    }
+
+    public function getTitle(): string
+    {
+        return 'New Member';
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            MemberResource::getUrl('index')   => 'Members',
+        ];
     }
 }

--- a/app/Filament/Resources/MemberResource/Pages/EditMember.php
+++ b/app/Filament/Resources/MemberResource/Pages/EditMember.php
@@ -13,9 +13,24 @@ class EditMember extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Actions\ViewAction::make(),
             Actions\DeleteAction::make(),
             Actions\ForceDeleteAction::make(),
             Actions\RestoreAction::make(),
+        ];
+    }
+
+    public function getTitle(): string
+    {
+        return 'Edit ' . $this->record->name;
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            MemberResource::getUrl('index')   => 'Members',
+            $this->record->name
         ];
     }
 }

--- a/app/Filament/Resources/MemberResource/Pages/ListMembers.php
+++ b/app/Filament/Resources/MemberResource/Pages/ListMembers.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\MemberResource\Pages;
 
+use App\Enums\Status;
 use App\Filament\Resources\MemberResource;
 use App\Models\Member;
 use Filament\Actions;
@@ -28,12 +29,20 @@ class ListMembers extends ListRecords
             'all' => Tab::make('All'),
             'active' => Tab::make('Active')
                 ->badge(Member::query()->where('status', 'active')->count())
-                ->badgeColor('success')
+                ->badgeColor(Status::Active->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'active')),
             'inactive' => Tab::make('Inactive')
                 ->badge(Member::query()->where('status', 'inactive')->count())
-                ->badgeColor('danger')
+                ->badgeColor(Status::Inactive->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'inactive')),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            MemberResource::getUrl('index')   => 'Members',
         ];
     }
 }

--- a/app/Filament/Resources/MemberResource/Pages/ViewMember.php
+++ b/app/Filament/Resources/MemberResource/Pages/ViewMember.php
@@ -11,16 +11,25 @@ class ViewMember extends ViewRecord
 {
     protected static string $resource = MemberResource::class;
 
-    public function getTitle(): string
-    {
-        return 'View ' . $this->record->name;
-    }
-
     protected function getHeaderActions(): array
     {
         return [
             EditAction::make(),
             DeleteAction::make()
+        ];
+    }
+
+    public function getTitle(): string
+    {
+        return 'Member ' . $this->record->name;
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            MemberResource::getUrl('index')   => 'Members',
+            $this->record->name
         ];
     }
 }

--- a/app/Filament/Resources/MemberResource/RelationManagers/SubscriptionsRelationManager.php
+++ b/app/Filament/Resources/MemberResource/RelationManagers/SubscriptionsRelationManager.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources\MemberResource\RelationManagers;
+
+use App\Filament\Resources\SubscriptionResource;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Table;
+
+class SubscriptionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'subscriptions';
+
+    protected static ?string $title = 'Manage Subscriptions';
+
+    /**
+     * Determine if the relation manager is read-only.
+     *
+     * @return bool Returns false, indicating the relation manager is not read-only.
+     */
+    public function isReadOnly(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Define the form schema for the resource.
+     *
+     * @param \Filament\Forms\Form $form
+     * @return \Filament\Forms\Form
+     */
+    public function form(Form $form): Form
+    {
+        return SubscriptionResource::form($form);
+    }
+
+    /**
+     * Define the table for listing records in the resource.
+     *
+     * @param \Filament\Tables\Table $table
+     * @return \Filament\Tables\Table
+     */
+    public function table(Table $table): Table
+    {
+        return SubscriptionResource::table($table)
+            ->headerActions([
+                CreateAction::make()
+                    ->icon('heroicon-s-plus')
+                    ->modalHeading('New Subscription')
+                    ->modalWidth('6xl')
+                    ->closeModalByClickingAway(false)
+                    ->createAnother(false)
+            ]);
+    }
+}

--- a/app/Filament/Resources/SubscriptionResource/Pages/CreateSubscription.php
+++ b/app/Filament/Resources/SubscriptionResource/Pages/CreateSubscription.php
@@ -3,10 +3,24 @@
 namespace App\Filament\Resources\SubscriptionResource\Pages;
 
 use App\Filament\Resources\SubscriptionResource;
-use Filament\Actions;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateSubscription extends CreateRecord
 {
     protected static string $resource = SubscriptionResource::class;
+
+    protected static bool $canCreateAnother = false;
+
+    public function getTitle(): string
+    {
+        return 'New Subscription';
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            SubscriptionResource::getUrl('index')   => 'Subscriptions',
+        ];
+    }
 }

--- a/app/Filament/Resources/SubscriptionResource/Pages/EditSubscription.php
+++ b/app/Filament/Resources/SubscriptionResource/Pages/EditSubscription.php
@@ -12,7 +12,7 @@ class EditSubscription extends EditRecord
 
     public function getTitle(): string
     {
-        return 'Edit ' . ' Subscription: ' . $this->record->member->name;
+        return 'Edit ' . $this->record->member->name;
     }
 
     protected function getHeaderActions(): array
@@ -22,6 +22,15 @@ class EditSubscription extends EditRecord
             Actions\DeleteAction::make(),
             Actions\ForceDeleteAction::make(),
             Actions\RestoreAction::make(),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            SubscriptionResource::getUrl('index')   => 'Subscriptions',
+            $this->record->member->name
         ];
     }
 }

--- a/app/Filament/Resources/SubscriptionResource/Pages/ListSubscriptions.php
+++ b/app/Filament/Resources/SubscriptionResource/Pages/ListSubscriptions.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\SubscriptionResource\Pages;
 
+use App\Enums\Status;
 use App\Filament\Resources\SubscriptionResource;
 use App\Models\Subscription;
 use Filament\Actions;
@@ -27,16 +28,24 @@ class ListSubscriptions extends ListRecords
             'all' => Tab::make('All'),
             'ongoing' => Tab::make('Ongoing')
                 ->badge(Subscription::query()->where('status', 'ongoing')->count())
-                ->badgeColor('success')
+                ->badgeColor(Status::Ongoing->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'ongoing')),
             'expiring' => Tab::make('Expiring')
                 ->badge(Subscription::query()->where('status', 'expiring')->count())
-                ->badgeColor('danger')
+                ->badgeColor(Status::Expiring->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'expiring')),
             'expired' => Tab::make('Expired')
                 ->badge(Subscription::query()->where('status', 'expired')->count())
-                ->badgeColor('danger')
+                ->badgeColor(Status::Expired->getColor())
                 ->modifyQueryUsing(fn(Builder $query) => $query->where('status', 'expired')),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            SubscriptionResource::getUrl('index')   => 'Subscriptions',
         ];
     }
 }

--- a/app/Filament/Resources/SubscriptionResource/Pages/ViewSubscription.php
+++ b/app/Filament/Resources/SubscriptionResource/Pages/ViewSubscription.php
@@ -13,7 +13,7 @@ class ViewSubscription extends ViewRecord
 
     public function getTitle(): string
     {
-        return 'View ' . ' Subscription: ' . $this->record->member->name;
+        return 'Subscription ' . $this->record->member->name;
     }
 
     protected function getHeaderActions(): array
@@ -21,6 +21,15 @@ class ViewSubscription extends ViewRecord
         return [
             EditAction::make(),
             DeleteAction::make()
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            'Memberships',
+            SubscriptionResource::getUrl('index')   => 'Subscriptions',
+            $this->record->member->name
         ];
     }
 }

--- a/app/Filament/Resources/SubscriptionResource/RelationManagers/InvoicesRelationManager.php
+++ b/app/Filament/Resources/SubscriptionResource/RelationManagers/InvoicesRelationManager.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Resources\SubscriptionResource\RelationManagers;
+
+use App\Filament\Resources\InvoiceResource;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Table;
+
+class InvoicesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'invoices';
+
+    protected static ?string $title = 'Manage Invoices';
+
+    /**
+     * Determine if the relation manager is read-only.
+     *
+     * @return bool Returns false, indicating the relation manager is not read-only.
+     */
+    public function isReadOnly(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Define the form schema for the resource.
+     *
+     * @param \Filament\Forms\Form $form
+     * @return \Filament\Forms\Form
+     */
+    public function form(Form $form): Form
+    {
+        return InvoiceResource::form($form);
+    }
+
+    /**
+     * Define the table for listing records in the resource.
+     *
+     * @param \Filament\Tables\Table $table
+     * @return \Filament\Tables\Table
+     */
+    public function table(Table $table): Table
+    {
+        return InvoiceResource::table($table)
+            ->headerActions([
+                CreateAction::make()
+                    ->icon('heroicon-s-plus')
+                    ->modalHeading('New Invoice')
+                    ->modalWidth('6xl')
+                    ->closeModalByClickingAway(false)
+                    ->createAnother(false)
+            ]);;
+    }
+}

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -3,31 +3,22 @@
 namespace App\Models;
 
 use App\Enums\Status;
-use App\Filament\Resources\MemberResource;
 use App\Helpers\Helpers;
-use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Group;
-use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Wizard;
 use Filament\Forms\Get;
-use Filament\Forms\Set;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\HtmlString;
-use Illuminate\Support\Js;
 
 class Member extends Model
 {
@@ -296,7 +287,7 @@ class Member extends Model
             ImageColumn::make('photo')
                 ->circular()
                 ->defaultImageUrl(fn(Member $record): ?string => 'https://ui-avatars.com/api/?background=000&color=fff&name=' . $record->name),
-            TextColumn::make('member_code')
+            TextColumn::make('code')
                 ->searchable(),
             TextColumn::make('name')
                 ->searchable()

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -159,6 +159,7 @@ class Member extends Model
                                 ->required()
                                 ->readOnly()
                                 ->disabled()
+                                ->dehydrated()
                                 ->default(fn(Get $get) => Helpers::generateLastNumber(
                                     'member',
                                     Member::class,

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -2,14 +2,25 @@
 
 namespace App\Models;
 
-use App\Filament\Resources\PlanResource;
+use App\Enums\Status;
+use App\Filament\Resources\MemberResource\Pages\CreateMember;
+use App\Helpers\Helpers;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Fieldset;
+use Filament\Forms\Components\Group;
+use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
-use Filament\Support\Enums\FontWeight;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Filament\Resources\MemberResource\RelationManagers\SubscriptionsRelationManager;
 
 class Subscription extends Model
 {
@@ -31,6 +42,7 @@ class Subscription extends Model
     protected $casts = [
         'start_date' => 'date',
         'end_date'   => 'date',
+        'status'     => Status::class
     ];
 
     protected $dates = ['deleted_at', 'start_date', 'end_date'];
@@ -73,40 +85,186 @@ class Subscription extends Model
     public static function getForm(): array
     {
         return [
-            Select::make('member_id')
-                ->relationship('member', 'name')
-                ->native(false)
-                ->searchable()
-                ->preload()
-                ->placeholder('Select a member')
-                ->getOptionLabelFromRecordUsing(fn(Member $record): string => "{$record->code} - {$record->name}")
-                ->required(),
-            Select::make('plan_id')
-                ->relationship('plan', 'name')
-                ->native(false)
-                ->searchable()
-                ->preload()
-                ->placeholder('Select a plan')
-                ->getOptionLabelFromRecordUsing(fn(Plan $record): string => "{$record->code} - {$record->name}")
-                ->required(),
-            DatePicker::make('start_date')
-                ->label('Start Date')
-                ->live()
-                ->native(false)
-                ->required()
-                ->placeholder('01-01-2001')
-                ->displayFormat('d-m-Y')
-                ->suffixIcon('heroicon-m-calendar-days')
-                ->before('end_date'),
-            DatePicker::make('end_date')
-                ->label('End Date')
-                ->live()
-                ->native(false)
-                ->required()
-                ->placeholder('01-01-2001')
-                ->displayFormat('d-m-Y')
-                ->suffixIcon('heroicon-m-calendar-days')
-                ->after('start_date'),
+            Group::make()
+                ->columns(4)
+                ->columnSpanFull()
+                ->schema([
+                    Select::make('member_id')
+                        ->relationship('member', 'name')
+                        ->placeholder('Select a member')
+                        ->getOptionLabelFromRecordUsing(fn(Member $record): string => "{$record->code} - {$record->name}")
+                        ->hiddenOn([SubscriptionsRelationManager::class, CreateMember::class])
+                        ->required(),
+                    Select::make('plan_id')
+                        ->columnSpan(fn($livewire) => ($livewire instanceof SubscriptionsRelationManager ||
+                            $livewire instanceof CreateMember)
+                            ? 2
+                            : 1)
+                        ->relationship('plan', 'name')
+                        ->placeholder('Select a plan')
+                        ->reactive()
+                        ->getOptionLabelFromRecordUsing(fn(Plan $record): string => "{$record->code} - {$record->name}")
+                        ->afterStateUpdated(function (Get $get, Set $set) {
+                            $plan    = \App\Models\Plan::find($get('plan_id'));
+                            $fee     = round($plan->amount ?? 0);
+                            $taxRate = Helpers::getTaxRate() ?: 0;
+                            $tax     = round(($fee * $taxRate) / 100);
+
+                            // grab current invoices array (if any)
+                            $invoices = $get('invoices') ?? [];
+
+                            foreach ($invoices as $index => $invoice) {
+                                $discount = $invoice['discount_amount'] ?? 0;
+                                $paid     = $invoice['paid_amount']     ?? 0;
+                                $total    = round($fee + $tax - $discount);
+                                $due      = round(max($total - $paid, 0));
+
+                                // set each nested invoice field
+                                $set("invoices.{$index}.subscription_fee", $fee);
+                                $set("invoices.{$index}.tax",              $tax);
+                                $set("invoices.{$index}.total_amount",     $total);
+                                $set("invoices.{$index}.due_amount",       $due);
+                            }
+                        })
+                        ->required(),
+                    DatePicker::make('start_date')
+                        ->label('Start Date')
+                        ->live()
+                        ->required()
+                        ->before('end_date'),
+                    DatePicker::make('end_date')
+                        ->label('End Date')
+                        ->live()
+                        ->required()
+                        ->after('start_date'),
+                ]),
+            Section::make('Invoice Details')
+                ->visibleOn('create')
+                ->schema(
+                    [
+                        Repeater::make('invoices')
+                            ->relationship('invoices')
+                            ->itemLabel('')
+                            ->hiddenLabel()
+                            ->columnSpanFull()
+                            ->maxItems(1)
+                            ->deletable(false)
+                            ->columns(4)
+                            ->extraAttributes(['class' => 'rmv_rept-space'])
+                            ->schema([
+                                Group::make()
+                                    ->columns(3)
+                                    ->columnSpan(3)
+                                    ->schema([
+                                        TextInput::make('number')
+                                            ->label('Invoice No.')
+                                            ->required()
+                                            ->readOnly()
+                                            ->disabled()
+                                            ->dehydrated()
+                                            ->unique('invoices', 'number')
+                                            ->default(fn(Get $get) => Helpers::generateLastNumber(
+                                                'invoice',
+                                                Invoice::class,
+                                                $get('date')
+                                            )),
+                                        DatePicker::make('date')
+                                            ->label('Date')
+                                            ->required()
+                                            ->reactive()
+                                            ->default(now()),
+                                        DatePicker::make('due_date')
+                                            ->label('Due Date')
+                                            ->required()
+                                            ->reactive(),
+                                        Select::make('discount')
+                                            ->label('Discount')
+                                            ->options(Helpers::getDiscounts())
+                                            ->live()
+                                            ->reactive()
+                                            ->placeholder('Select Discount')
+                                            ->afterStateUpdated(
+                                                function (Get $get, Set $set) {
+                                                    $fee           = $get('subscription_fee') ?: 0;
+                                                    $tax           = $get('tax') ?: 0;
+                                                    $discountPct   = (int) $get('discount');
+                                                    $discountAmount = Helpers::getDiscountAmount($discountPct, $fee);
+                                                    $total         = $fee + $tax - $discountAmount;
+
+                                                    $set('discount_amount', round($discountAmount));
+                                                    $set('total_amount', round($total));
+                                                    $set('due_amount', max($total - $get('paid_amount'), 0));
+                                                }
+                                            ),
+                                        TextInput::make('discount_amount')
+                                            ->label('Discount Amount')
+                                            ->numeric()
+                                            ->debounce(300)
+                                            ->default(0)
+                                            ->prefix(Helpers::getCurrencySymbol())
+                                            ->maxValue(fn(Get $get): float => $get('subscription_fee') ?: 0)
+                                            ->afterStateUpdated(
+                                                function (Get $get, Set $set, $livewire, TextInput $component) {
+                                                    $livewire->validateOnly($component->getStatePath());
+
+                                                    $fee            = $get('subscription_fee') ?: 0;
+                                                    $entered        = $get('discount_amount') ?: 0;
+                                                    $clamped        = min(max($entered, 0), $fee);
+                                                    $tax            = $get('tax') ?: 0;
+                                                    $total          = $fee + $tax - $clamped;
+
+                                                    $set('total_amount', round($total));
+                                                    $set('due_amount', max($total - $get('paid_amount'), 0));
+                                                }
+                                            ),
+                                        Textarea::make('discount_note')
+                                            ->label('Discount Note')
+                                            ->placeholder('E.g. introductory offer'),
+                                        Radio::make('payment_method')
+                                            ->label('Payment Method')
+                                            ->options([
+                                                'cash'   => 'Cash',
+                                                'cheque' => 'Cheque',
+                                            ])
+                                            ->default('cash')
+                                            ->inline()
+                                            ->inlineLabel(false)
+                                            ->required(),
+                                    ]),
+                                Fieldset::make('Summary')
+                                    ->columns(1)
+                                    ->columnSpan(1)
+                                    ->schema([
+                                        TextInput::make('subscription_fee')
+                                            ->label('Subscription Fee')
+                                            ->numeric()
+                                            ->readOnly()
+                                            ->disabled()
+                                            ->dehydrated()
+                                            ->default(0)
+                                            ->prefix(Helpers::getCurrencySymbol())
+                                            ->required(),
+                                        TextInput::make('tax')
+                                            ->label('Tax (' . Helpers::getTaxRate() . '%)')
+                                            ->numeric()
+                                            ->disabled()
+                                            ->dehydrated()
+                                            ->default(0)
+                                            ->prefix(Helpers::getCurrencySymbol())
+                                            ->readOnly(),
+                                        TextInput::make('total_amount')
+                                            ->label('Total Amount')
+                                            ->numeric()
+                                            ->readOnly()
+                                            ->disabled()
+                                            ->dehydrated()
+                                            ->default(0)
+                                            ->prefix(Helpers::getCurrencySymbol())
+                                            ->required(),
+                                    ]),
+                            ]),
+                    ]
+                )
         ];
     }
 
@@ -136,18 +294,7 @@ class Subscription extends Model
                 ->date()
                 ->toggleable(isToggledHiddenByDefault: true),
             TextColumn::make('status')
-                ->badge()
-                ->color(fn(string $state): string => match ($state) {
-                    'ongoing' => 'success',
-                    'expiring' => 'warning',
-                    'expired' => 'danger',
-                })
-                ->formatStateUsing(fn(string $state): string => match ($state) {
-                    'ongoing' => 'Ongoing',
-                    'expiring' => 'Expiring',
-                    'expired' => 'Expired',
-                    default => ucfirst($state),
-                }),
+                ->badge(),
         ];
     }
 }

--- a/public/css/app/gymie-styles.css
+++ b/public/css/app/gymie-styles.css
@@ -1,6 +1,8 @@
-.new_enquiry_follow_up li {
+.new_enquiry_follow_up li,
+.rmv_rept-space li {
     box-shadow: none;
 }
-.new_enquiry_follow_up .fi-fo-repeater-item-content {
+.new_enquiry_follow_up .fi-fo-repeater-item-content,
+.rmv_rept-space .fi-fo-repeater-item-content {
     padding: 0px;
 }

--- a/resources/css/custom.css
+++ b/resources/css/custom.css
@@ -1,6 +1,8 @@
-.new_enquiry_follow_up li {
+.new_enquiry_follow_up li,
+.rmv_rept-space li {
     box-shadow: none;
 }
-.new_enquiry_follow_up .fi-fo-repeater-item-content {
+.new_enquiry_follow_up .fi-fo-repeater-item-content,
+.rmv_rept-space .fi-fo-repeater-item-content {
     padding: 0px;
 }


### PR DESCRIPTION
### Summary
This PR addresses to makes sure that a member can’t be created without also adding a subscription and an invoice.

### Related Issue
Closes #190 

### Changes

- Added `Subscription` and `Invoice` sections to the Member creation form.
- Implemented form-level validation to block submission unless both sections are properly filled.
- Refactored Subscription and Invoice resource code to improve structure and maintainability.
- Updated the UI for both sections to be more consistent and user-friendly.

> [!NOTE]
> Some parts of the invoice calculation code still need improvement this will be done in a future update.
> The current layout and design of the Subscription and Invoice sections inside the form works for now, but I am not sure if it’s the best experience. Would love help or feedback on improving the design/UX.

### Screenshots / Screen Recording / Logs

https://github.com/user-attachments/assets/a869efca-506b-4041-a65a-ed1c2cc29455

