### PR TITLE
Feat(subscription-form): Auto-calculate subscription end date based on selected plan

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -2,6 +2,7 @@
 
 namespace App\Helpers;
 
+use App\Models\Plan;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Support\Facades\Schema;
@@ -435,5 +436,25 @@ class Helpers
             storage_path(self::SETTINGS_PATH),
             json_encode($settings, JSON_PRETTY_PRINT)
         );
+    }
+
+    /**
+     * Given a subscription start date and a plan ID, return the Y-m-d end date
+     * (or empty string if no valid plan/days).
+     */
+    public static function calculateSubscriptionEndDate(?string $startDate, ?int $planId): string
+    {
+        if (! $startDate || ! $planId) {
+            return '';
+        }
+
+        $plan = Plan::find($planId);
+        if (! $plan || ! $plan->days) {
+            return '';
+        }
+
+        return Carbon::parse($startDate)
+            ->addDays($plan->days)
+            ->toDateString();
     }
 }


### PR DESCRIPTION
### Summary
This PR implements the auto-calculation of the subscription end date in the form based on the selected plan's duration (in days). When a user selects a plan, the end date is automatically set by adding the plan's number of days to the start date. The end date also updates dynamically if the start date is changed.

### Related Issue
Closes #196 

### Screenshots / Screen Recording / Logs

https://github.com/user-attachments/assets/f2fc0f05-b410-4155-8951-97637d1a8cee

