### PR TITLE
Feat(subscription): Add daily scheduler to auto-update subscription statuses

### DIFF
--- a/app/Console/Commands/MarkSubscriptionsStatus.php
+++ b/app/Console/Commands/MarkSubscriptionsStatus.php
@@ -39,7 +39,7 @@ class MarkSubscriptionsStatus extends Command
             ->update(['status' => 'expired']);
 
         // Mark those about to expire in next 7 days
-        $expiringCount = Subscription::whereBetween('start_date', [$now, $expiringThreshold])
+        $expiringCount = Subscription::whereBetween('end_date', [$now, $expiringThreshold])
             ->where('status', '!=', 'expiring')
             ->update(['status' => 'expiring']);
 

--- a/app/Console/Commands/MarkSubscriptionsStatus.php
+++ b/app/Console/Commands/MarkSubscriptionsStatus.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Subscription;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
+use Filament\Notifications\Notification;
+use Illuminate\Console\Command;
+
+class MarkSubscriptionsStatus extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'subscriptions:mark-status';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Mark subscriptions as expiring or expired';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $now = Carbon::now();
+        $expiringThreshold = $now->copy()->addDays(7);
+
+        // Mark already expired
+        $expiredCount = Subscription::where('end_date', '<', $now)
+            ->where('status', '!=', 'expired')
+            ->update(['status' => 'expired']);
+
+        // Mark those about to expire in next 7 days
+        $expiringCount = Subscription::whereBetween('start_date', [$now, $expiringThreshold])
+            ->where('status', '!=', 'expiring')
+            ->update(['status' => 'expiring']);
+
+        $expiredLabel  = Str::plural('subscription', $expiredCount);
+        $expiringLabel = Str::plural('subscription', $expiringCount);
+
+        $this->info("✅ Marked {$expiredCount} {$expiredLabel} as expired.");
+        $this->info("⏳ Marked {$expiringCount} {$expiringLabel} as expiring soon (within 7 days).");
+
+        $summary = "Subscriptions updated: {$expiredCount} expired, {$expiringCount} expiring soon.";
+
+        $admin = User::role('super_admin')->first();
+
+        Notification::make()
+            ->title('Subscription Status Update')
+            ->body($summary)
+            ->info()
+            ->sendToDatabase($admin);
+
+        $this->info("🔔 Notification sent to {$admin->name} dashboard.");
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,5 +8,10 @@ Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-Schedule::command('subscriptions:mark-status')
-    ->dailyAt('00:00');
+// Mark subscriptions expired every day at 00:00
+Schedule::command('gymie:subscriptions --mark-expired')
+    ->everyMinute();
+
+// Mark subscriptions expiring soon every day at 00:05
+Schedule::command('gymie:subscriptions --mark-expiring')
+    ->everyMinute();

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,12 @@
 <?php
 
+use Illuminate\Support\Facades\Schedule;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('subscriptions:mark-status')
+    ->dailyAt('00:00');


### PR DESCRIPTION
### Summary
This PR implements an Artisan command and scheduler to automatically mark subscriptions as expiring (before end_date) or expired (once end_date is reached), dispatching events for notifications.

### Related Issue
Closes #191 

> [!NOTE]
> After deploying, you can manually trigger status updates with:
> ```bash
> php artisan subscriptions:mark-status
> ```
> 
> Ensure your queue worker is running to handle any notification jobs:
> ```bash
> php artisan queue:work 
> ```
