### PR TITLE
Feat(invoice): Add Artisan Command and Scheduler to Mark Overdue Invoices

### DIFF
--- a/app/Console/Commands/MarkInvoiceOverdue.php
+++ b/app/Console/Commands/MarkInvoiceOverdue.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Invoice;
+use Illuminate\Console\Command;
+
+class MarkInvoiceOverdue extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'gymie:invoices {--mark-overdue : Mark invoices as overdue based on due date}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Perform operations on invoices (e.g., mark as overdue)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $updatedCount = Invoice::where('status', 'issue')
+            ->whereDate('due_date', '<=', now())
+            ->update(['status' => 'overdue']);
+
+        $this->info("{$updatedCount} invoice(s) marked as overdue.");
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,8 +10,12 @@ Artisan::command('inspire', function () {
 
 // Mark subscriptions expired every day at 00:00
 Schedule::command('gymie:subscriptions --mark-expired')
-    ->everyMinute();
+    ->dailyAt('00:00');
 
 // Mark subscriptions expiring soon every day at 00:05
 Schedule::command('gymie:subscriptions --mark-expiring')
-    ->everyMinute();
+    ->dailyAt('00:00');
+
+// Mark invoices overdue every day at 00:00
+Schedule::command('gymie:invoices --mark-overdue')
+    ->dailyAt('00:00');


### PR DESCRIPTION
### Summary
This PR introduces an Artisan console command to mark invoices as overdue based on their due date. It also adds the command to the Laravel scheduler so the process runs automatically every day.

### Related Issue
Closes #167 

> [!NOTE]
> Run the command manually:
> ```bash
> php artisan gymie:invoices --mark-overdue 
> ```
