### PR TITLE
Fix shared PHPStan compatibility

### DIFF
--- a/app/Filament/Resources/Enquiries/EnquiryResource.php
+++ b/app/Filament/Resources/Enquiries/EnquiryResource.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
+/** @extends resource<Enquiry> */
 class EnquiryResource extends Resource
 {
     protected static ?string $model = Enquiry::class;

--- a/app/Filament/Resources/Invoices/InvoiceResource.php
+++ b/app/Filament/Resources/Invoices/InvoiceResource.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
+/** @extends resource<Invoice> */
 class InvoiceResource extends Resource
 {
     protected static ?string $model = Invoice::class;

--- a/app/Filament/Resources/Members/MemberResource.php
+++ b/app/Filament/Resources/Members/MemberResource.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 
+/** @extends resource<Member> */
 class MemberResource extends Resource
 {
     protected static ?string $model = Member::class;

--- a/app/Http/Controllers/Api/V1/InvoicesController.php
+++ b/app/Http/Controllers/Api/V1/InvoicesController.php
@@ -138,7 +138,7 @@ class InvoicesController extends ApiController
         } catch (InvoiceDocumentNotRenderable $exception) {
             return response()->json([
                 'message' => 'Invoice can’t be generated.',
-                'missing' => $exception->viewData['missing'] ?? [],
+                'missing' => $exception->viewData['missing'],
             ], 422);
         }
 
@@ -162,7 +162,7 @@ class InvoicesController extends ApiController
         } catch (InvoiceDocumentNotRenderable $exception) {
             return response()->json([
                 'message' => 'Invoice can’t be generated.',
-                'missing' => $exception->viewData['missing'] ?? [],
+                'missing' => $exception->viewData['missing'],
             ], 422);
         }
 

--- a/app/Jobs/SendInvoiceIssuedEmail.php
+++ b/app/Jobs/SendInvoiceIssuedEmail.php
@@ -53,7 +53,7 @@ class SendInvoiceIssuedEmail implements ShouldQueue
         } catch (InvoiceDocumentNotRenderable $exception) {
             Log::warning('Skipping invoice email: missing required invoice data.', [
                 'invoice_id' => $this->invoiceId,
-                'missing' => $exception->viewData['missing'] ?? [],
+                'missing' => $exception->viewData['missing'],
             ]);
         }
     }

--- a/app/Jobs/SendInvoicePaymentReceiptEmail.php
+++ b/app/Jobs/SendInvoicePaymentReceiptEmail.php
@@ -56,7 +56,7 @@ class SendInvoicePaymentReceiptEmail implements ShouldQueue
             Log::warning('Skipping payment receipt email: missing required invoice data.', [
                 'invoice_id' => $this->invoiceId,
                 'invoice_transaction_id' => $this->invoiceTransactionId,
-                'missing' => $exception->viewData['missing'] ?? [],
+                'missing' => $exception->viewData['missing'],
             ]);
         }
     }


### PR DESCRIPTION
Moves the PHPStan 2.2 compatibility fixes into the OSS-owned runtime so the hosted platform can consume them without maintaining overrides. Adds concrete Filament resource generics and uses the guaranteed invoice rendering error shape.\n\nVerification:\n- 81 Pest tests / 358 assertions\n- Pint clean\n- Platform OSS ownership check passes